### PR TITLE
Removing the xui-webapp cookie manipulation as no longer required

### DIFF
--- a/src/gatling/simulations/scenarios/Caseworker_Navigation.scala
+++ b/src/gatling/simulations/scenarios/Caseworker_Navigation.scala
@@ -165,9 +165,10 @@ object Caseworker_Navigation {
         //re-injecting the valid xui-webapp cookie, as for an unknown reason, XUI or Gatling changes the cookie value between
         //these two steps (media viewer and binary download), so it was trying to use an invalid cookie to retrieve
         //the doc, and throwing an http 401. This is the same as the 401 issue at login. Cause is unknown.
-        .exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}")
-          .withMaxAge(28800)
-          .withSecure(true)))
+        //UPDATE MAY 2026: This is no longer required, so could probably be removed in the future
+        //.exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}")
+        //  .withMaxAge(28800)
+        //  .withSecure(true)))
 
         .exec(http("XUI_Caseworker_090_010_ViewDocument")
           .get("/documentsv2/#{documentLink}/binary")

--- a/src/gatling/simulations/scenarios/Solicitor_PRL_C100.scala
+++ b/src/gatling/simulations/scenarios/Solicitor_PRL_C100.scala
@@ -803,7 +803,8 @@ object Solicitor_PRL_C100 {
       //see xui-webapp cookie capture in the Homepage scenario for details of why this is being used.
       //after a period of time during a performance test, the cookie would change and subsequent calls would fail
       //with a 401 unauthorized, so this code is forcing the original cookie back in to the Gatling session
-      .exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}").withMaxAge(28800).withSecure(true)))
+      //UPDATE MAY 2026: This is no longer required, so could probably be removed in the future
+      //.exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}").withMaxAge(28800).withSecure(true)))
 
       .exec(Common.configurationui)
       .exec(Common.configJson)

--- a/src/gatling/simulations/scenarios/Solicitor_Probate.scala
+++ b/src/gatling/simulations/scenarios/Solicitor_Probate.scala
@@ -537,9 +537,10 @@ object Solicitor_Probate {
       //see xui-webapp cookie capture in the Homepage scenario for details of why this is being used.
       //after a period of time during a performance test, the cookie would change and subsequent calls would fail
       //with a 401 unauthorized, so this code is forcing the original cookie back in to the Gatling session
-      .exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}")
-        .withMaxAge(28800)
-        .withSecure(true)))
+      //UPDATE MAY 2026: This is no longer required, so could probably be removed in the future
+      //.exec(addCookie(Cookie("xui-webapp", "#{xuiWebAppCookie}")
+      //  .withMaxAge(28800)
+      //  .withSecure(true)))
 
       .exec(Common.activity)
 


### PR DESCRIPTION
As of May 2026 the xui-webapp cookie manipulation that was previously needed is no longer required.

See the commented code for why this was previously needed, and the code could probably be completely removed in the future.

The code has also been commented out in common-performance, where it captures and injects the cookie at the Homepage/Login steps.